### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+**nvAux** is a browser-based note-taking PWA (Svelte 4 + Vite 4). There is no backend — all data lives in IndexedDB via RxDB/Dexie.
+
+### Services
+
+| Service | Command | Port |
+|---------|---------|------|
+| Vite dev server | `npm run dev` | 5173 (binds `0.0.0.0` via `--host`) |
+
+### Key commands
+
+- **Install deps:** `npm install` (lockfile: `package-lock.json`)
+- **Dev server:** `npm run dev`
+- **Build:** `npm run build` (produces a single-file `dist/index.html` via `vite-plugin-singlefile`)
+- **Preview prod build:** `npm run preview`
+
+### Notes
+
+- No lint or test scripts are configured in `package.json`. Prettier config (`.prettierrc`) exists for formatting.
+- Build emits a single CSS selector warning in `NoteList.svelte` (unused `.context-menu-wrapper`) — this is pre-existing and benign.
+- No environment variables or external services are needed; everything runs client-side.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the nvAux project.

## What's included

- Service overview (Vite dev server on port 5173)
- Key commands: install, dev, build, preview
- Notes about the absence of lint/test scripts, pre-existing build warning, and the client-only architecture

## Dev environment verification

The development environment was fully set up and verified:

- `npm install` — all 284 packages installed
- `npm run build` — single-file production build succeeds
- `npm run dev` — Vite dev server starts on port 5173
- Hello-world task: created notes and edited content in the browser

[nvaux_demo_create_notes.mp4](https://cursor.com/agents/bc-f5c35c7b-7561-440f-a2da-9f3741ecc1ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnvaux_demo_create_notes.mp4)

[nvAux with multiple notes](https://cursor.com/agents/bc-f5c35c7b-7561-440f-a2da-9f3741ecc1ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnvaux_two_notes_sidebar.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5c35c7b-7561-440f-a2da-9f3741ecc1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5c35c7b-7561-440f-a2da-9f3741ecc1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

